### PR TITLE
Fixing import error

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,9 +1,9 @@
 const express = require('express')
-const expressGraphQL = require('express-graphql')
+const { graphqlHTTP } = require('express-graphql')
 const schema = require('./schema')
 
 const app = express()
-app.use('/graphql', expressGraphQL({
+app.use('/graphql', graphqlHTTP({
     schema,
     graphiql: true
 }))


### PR DESCRIPTION
This will close issue (https://github.com/ankitamasand/gql-server/issues/2) .

I think it is worth to merge this fix because the tutorial is great and it is being referred on Stackoverflow. See comments on the answer: https://stackoverflow.com/questions/65517979/expressgraphql-is-not-a-function